### PR TITLE
SickRage team has moved to a new organization

### DIFF
--- a/init/20_update.sh
+++ b/init/20_update.sh
@@ -3,7 +3,7 @@ mkdir -p /app
 chown abc:abc /app
 
 if [ ! -d /app/sickrage/.git ]; then 
-	/sbin/setuser abc git clone https://github.com/SiCKRAGETV/SickRage.git /app/sickrage
+	/sbin/setuser abc git clone https://github.com/SickRage/SickRage.git /app/sickrage
 else
 	cd /app/sickrage
 	/sbin/setuser abc git pull


### PR DESCRIPTION
As a team, we have moved from the old org (SiCKRAGETV) to a new org (SickRage), only leaving echelon behind. New org is nearing 2k commits ahead of the old one and is much more stable and maintained, as well as a much larger user base as users have opted to move with the team.
For questions, we are on freenode in #sickrage-issues
